### PR TITLE
As a user I should see the Gift Suggestion Sliders start in a neutral position instead of at a value of 0.

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -175,9 +175,9 @@ function Onboarding() {
       categories: [],
       hobbies: '',
       giftRestrictions: '',
-      giftPersonality: 50,
-      experienceStyle: 50,
-      giftStyle: 50,
+      giftPersonality: 0,
+      experienceStyle: 0,
+      giftStyle: 0,
     },
   });
 
@@ -443,7 +443,7 @@ function Onboarding() {
                           <FormLabel>Gift Personality</FormLabel>
                           <FormControl>
                             <Slider
-                              min={0}
+                              min={-100}
                               max={100}
                               value={[field.value]}
                               onValueChange={(values) =>
@@ -468,7 +468,7 @@ function Onboarding() {
                           <FormLabel>Experience Style</FormLabel>
                           <FormControl>
                             <Slider
-                              min={0}
+                              min={-100}
                               max={100}
                               value={[field.value]}
                               onValueChange={(values) =>
@@ -493,7 +493,7 @@ function Onboarding() {
                           <FormLabel>Gift Style</FormLabel>
                           <FormControl>
                             <Slider
-                              min={0}
+                              min={-100}
                               max={100}
                               value={[field.value]}
                               onValueChange={(values) =>


### PR DESCRIPTION
Closes #129 

With the default set to 0 for shadcn slider component, any negative `min` value will be to the left of the slider. So, putting an equal positive and negative value for both sides will put the slider in the middle with a value of 0.

Sliding to the left will change the value between 0 to -100
Sliding to the right will change the value between 0 to 100

With this it'll set up future tickets for us to be able to separate the two sides and add values to them enhancing openAI's prompt.

I also didn't add margin yet because the design most likely can change.


https://github.com/user-attachments/assets/805453dd-6d21-46e8-b1cf-0780fc59cf36

NOTE: I only showed the number for visual reasons then deleted that line of code.