### PR TITLE
fix: address eslint errors in dialog component

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -39,7 +39,6 @@ components/Calendar/calendar.tsx
 components/Card/card.tsx
 components/Command/command.tsx
 components/CompletedExchangeCard/CompletedExchangeCard.tsx
-components/Dialogue/dialog.tsx
 components/FeedbackView/FeedbackView.tsx
 components/Form/form.tsx
 components/GiftDetailsView/GiftDetailsView.tsx

--- a/components/Dialogue/dialog.tsx
+++ b/components/Dialogue/dialog.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
 'use client';
 
 import * as React from 'react';
@@ -53,10 +56,16 @@ const DialogContent = React.forwardRef<
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
+/**
+ * Function that renders the header for the dialog component.
+ * @param props - Props for function
+ * @param props.className - Additional CSS classes for custom styling.
+ * @returns The rendered dialog header element.
+ */
 const DialogHeader = ({
   className,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+}: React.HTMLAttributes<HTMLDivElement>): React.JSX.Element => (
   <div
     className={cn(
       'flex flex-col space-y-1.5 text-center sm:text-left',
@@ -67,10 +76,16 @@ const DialogHeader = ({
 );
 DialogHeader.displayName = 'DialogHeader';
 
+/**
+ * Function that renders the footer for the dialog component.
+ * @param props - Props for function
+ * @param props.className - Additional CSS classes for custom styling.
+ * @returns The rendered dialog footer element.
+ */
 const DialogFooter = ({
   className,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+}: React.HTMLAttributes<HTMLDivElement>): React.JSX.Element => (
   <div
     className={cn(
       'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',


### PR DESCRIPTION
Closes #255 

Addresses the following eslint errors in the dialog Component:

- Line 1:1
  - Error: missing header header/header
- Line 56:22
  - Error: Missing JSDoc comment. jsdoc/require-jsdoc
- LIne 59:42
  - Error: Missing return type on function. @typescript-eslint/explicit-function-return-type
- Line 70:22
  - Error: Missing JSDoc comment. jsdoc/require-jsdoc
- Line 73:42
  - Error: Missing return type on function. @typescript-eslint/explicit-function-return-type

**NOTE:** The issue mentioned these other errors, but they may have been addressed already. When I ran `npx eslint ./components/Dialogue/dialog.tsx`, these errors did not show up in the terminal:
  
- Line 20:6
  - Error: 'className' is missing in props validation react/prop-types
- Line 35:6
  - Error: 'className' is missing in props validation react/prop-types
- Line 87:6
  - Error: 'className' is missing in props validation react/prop-types
- Line 102:6
  - Error: 'className' is missing in props validation react/prop-types
