### PR TITLE
Hadi/194-create-unit-tests-for-input

### DIFF
--- a/components/Input/input.test.tsx
+++ b/components/Input/input.test.tsx
@@ -7,12 +7,12 @@ import { Input } from './input';
 describe('Input', () => {
   it('renders input correctly', () => {
     render(<Input />);
-    const testInput = screen.getByTestId('test-input');
+    const testInput = screen.getByTestId('input');
     expect(testInput).toBeInTheDocument();
   });
   it('renders an input with a custom class name', () => {
     render(<Input className="my-custom" />);
-    const input = screen.getByTestId('test-input');
+    const input = screen.getByTestId('input');
     expect(input).toHaveClass('my-custom');
   });
   it('forwards child props to the input', () => {
@@ -24,10 +24,11 @@ describe('Input', () => {
         value="test-value"
       />,
     );
-    const input = screen.getByTestId('test-input');
+    const input = screen.getByTestId('input');
     expect(input).toHaveAttribute('type', 'email');
     expect(input).toHaveAttribute('name', 'test-name');
     expect(input).toHaveAttribute('aria-label', 'test-aria-label');
     expect(input).toHaveValue('test-value');
   });
+ 
 });

--- a/components/Input/input.test.tsx
+++ b/components/Input/input.test.tsx
@@ -1,25 +1,33 @@
 // Copyright (c) Gridiron Survivor.
 // Licensed under the MIT License.
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Input } from './input';
 
 describe('Input', () => {
   it('renders input correctly', () => {
-    const { getByPlaceholderText } = render(
-      <Input placeholder="Placeholder text" />,
+    render(<Input />);
+    const testInput = screen.getByTestId('test-input');
+    expect(testInput).toBeInTheDocument();
+  });
+  it('renders an input with a custom class name', () => {
+    render(<Input className="my-custom" />);
+    const input = screen.getByTestId('test-input');
+    expect(input).toHaveClass('my-custom');
+  });
+  it('forwards child props to the input', () => {
+    render(
+      <Input
+        type="email"
+        name="test-name"
+        aria-label="test-aria-label"
+        value="test-value"
+      />,
     );
-    expect(getByPlaceholderText('Placeholder text')).toBeInTheDocument();
-  });
-  it('renders correct input type', () => {
-    const { getByRole } = render(<Input type="email" />);
-    const input = getByRole('textbox');
+    const input = screen.getByTestId('test-input');
     expect(input).toHaveAttribute('type', 'email');
-  });
-  it('renders an input with correct class names', () => {
-    const { getByRole } = render(<Input className="my-custom"/>);
-    const input = getByRole("textbox")
-    expect(input).toHaveClass("my-custom")
-    expect(input).toHaveClass("rounded-md")
+    expect(input).toHaveAttribute('name', 'test-name');
+    expect(input).toHaveAttribute('aria-label', 'test-aria-label');
+    expect(input).toHaveValue('test-value');
   });
 });

--- a/components/Input/input.test.tsx
+++ b/components/Input/input.test.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+import { render } from '@testing-library/react';
+import { Input } from './input';
+
+describe('Input', () => {
+  it('renders input correctly', () => {
+    const { getByPlaceholderText } = render(
+      <Input placeholder="Placeholder text" />,
+    );
+    expect(getByPlaceholderText('Placeholder text')).toBeInTheDocument();
+  });
+  it('renders correct input type', () => {
+    const { getByRole } = render(<Input type="email" />);
+    const input = getByRole('textbox');
+    expect(input).toHaveAttribute('type', 'email');
+  });
+  it('renders an input with correct class names', () => {
+    const { getByRole } = render(<Input className="my-custom"/>);
+    const input = getByRole("textbox")
+    expect(input).toHaveClass("my-custom")
+    expect(input).toHaveClass("rounded-md")
+  });
+});

--- a/components/Input/input.test.tsx
+++ b/components/Input/input.test.tsx
@@ -21,7 +21,7 @@ describe('Input', () => {
         type="email"
         name="test-name"
         aria-label="test-aria-label"
-        value="test-value"
+        defaultValue="test-value"
       />,
     );
     const input = screen.getByTestId('input');

--- a/components/Input/input.tsx
+++ b/components/Input/input.tsx
@@ -6,7 +6,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
   ({ className, type, ...props }, ref) => {
     return (
       <input
-        data-testid="test-input"
+        data-testid="input"
         type={type}
         className={cn(
           'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',

--- a/components/Input/input.tsx
+++ b/components/Input/input.tsx
@@ -6,6 +6,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
   ({ className, type, ...props }, ref) => {
     return (
       <input
+        data-testid="test-input"
         type={type}
         className={cn(
           'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest",
+    "test": "cross-env NODE_ENV=development jest",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },


### PR DESCRIPTION
Closes #194 

### Before:
The Input component (`components/Input/input.tsx`) was missing unit tests to verify functionality:

- No tests for rendering an input
- No tests for rendering a correct input type
- No tests for default/custom class names

### After:
Created unit tests in `components/Input/input.test.tsx` that verify:

- The input renders correctly
- Input renders with a specific type, if given
- Default/custom classNames are applied to the input

![Screenshot 2025-04-17 at 7 39 30 PM](https://github.com/user-attachments/assets/70c11870-23da-4902-b719-f58d08c46cc6)

### Summary:
This PR adds unit test coverage for the Input component

