### PR TITLE
Danielle/132-make-create-group-button-accessible

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -42,7 +42,7 @@ export default function Dashboard() {
       <div className="flex items-center justify-between px-4 md:px-16 lg:px-32 xl:px-52 h-40">
         <h1 className="text-2xl font-semibold text-white">Dashboard</h1>
         <Button
-          className="hover:bg-primaryButtonYelow70 bg-primaryButtonYellow h-10 w-36 font-semibold text-sm"
+          className="hover:bg-primaryButtonYelow70 bg-primaryButtonYellow h-10 w-36 font-semibold text-sm text-foreground"
           asChild
         >
           <Link href="/create-group-page">Create Group</Link>


### PR DESCRIPTION
Closes #132 

BEFORE:

![button before](https://github.com/user-attachments/assets/f5cfa390-e757-45d6-b1c5-e517cb332221)
![button contrast start](https://github.com/user-attachments/assets/ad1ea8e0-3595-4ed1-ad6f-3ca0142424e5)


Insufficient color contrast between button background color and foreground text color to meet WCAG accessibility standards.

AFTER:

![create group button after](https://github.com/user-attachments/assets/af53452c-cad9-4966-93d2-95ec1e7a515f)
![button contrast after](https://github.com/user-attachments/assets/3482a9c9-9768-4a3f-99a8-aebda09df623)

Utilized existing `foreground` variable to update text color


This specific button was hard coded and not an existing variant of the `Button` component.