### PR TITLE
Will/247 address eslint errors in avatar

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -32,7 +32,6 @@ app/types/giftExchangeMember.ts
 app/types/giftSuggestion.ts
 app/types/profile.ts
 app/types/tailwindcss-motion.d.ts
-components/Avatar/Avatar.tsx
 components/Avatar/AvatarFallback.tsx
 components/Avatar/AvatarBody.tsx
 components/Button/button.tsx

--- a/components/Avatar/Avatar.tsx
+++ b/components/Avatar/Avatar.tsx
@@ -1,11 +1,18 @@
 // Copyright (c) Gridiron Survivor.
 // Licensed under the MIT License.
 
+import { JSX } from 'react';
+
 import { AvatarImage } from './AvatarImage';
 import { AvatarFallback } from './AvatarFallback';
 import { AvatarBody } from './AvatarBody';
 
-const Avatar = ({ userAvatar }: { userAvatar: string | undefined }) => {
+/**
+ * An Avatar component that displays a provided image URL or a default image if not provided.
+ * @param {string} userAvatar - URL string for the avatar image. If undefined, the AvatarFallback img will be used.
+ * @returns {JSX.Element} - The rendered Avatar element.
+ */
+const Avatar = ({ userAvatar }: { userAvatar: string | undefined }) : JSX.Element => {
   return (
     <AvatarBody>
       <AvatarImage src={userAvatar} alt="" />

--- a/components/Avatar/Avatar.tsx
+++ b/components/Avatar/Avatar.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
 import { AvatarImage } from './AvatarImage';
 import { AvatarFallback } from './AvatarFallback';
 import { AvatarBody } from './AvatarBody';


### PR DESCRIPTION
Addressed ESlint errors in Avatar. Added JSDoc comments.

There is a warning about using a Radix Image component in place of the current img tag. Though Shashi mentioned this should be addressed later on a separate ticket.

Closes #247