### PR TITLE
Hadi/282-address-eslint-errors-slider-component

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -61,7 +61,6 @@ components/Progress/progress.tsx
 components/RadioGroup/radio-group.tsx
 components/Select/select.tsx
 components/Skeleton/Skeleton.tsx
-components/Slider/slider.tsx
 components/SnowOverlayToggle/SnowOverlayToggle.tsx
 components/SnowOverlayWrapper/react-snow-overlay.d.ts
 lib/drawGiftExchange.ts

--- a/components/Slider/slider.tsx
+++ b/components/Slider/slider.tsx
@@ -1,13 +1,22 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
 'use client';
 
-import * as React from 'react';
+import { forwardRef, ElementRef, ComponentPropsWithoutRef, JSX } from 'react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 
 import { cn } from '@/lib/utils';
 
-const Slider = React.forwardRef<
-  React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+/**
+ * The Slider component.
+ * @param {ComponentPropsWithoutRef<typeof SliderPrimitive>} props - Props for the component.
+ * @param {string} props.className - Additional CSS classes for custom styling.
+ * @returns {JSX.Element} The rendered Slider element.
+ */
+const Slider = forwardRef<
+  ElementRef<typeof SliderPrimitive.Root>,
+  ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
 >(({ className, ...props }, ref) => (
   <SliderPrimitive.Root
     ref={ref}


### PR DESCRIPTION
Closes #282 

### Before:
The following ESLint errors were present in `./components/Slider/slider.tsx`:

- Line 1:1
  - Error: missing header header/header

### After: 
- Removed `components/Slider/slider.tsx` from `.eslintignore`
- Added the missing header (header/header)
- Added JSDoc comment for the slider component
- Imported only necessary React imports 

### Note:
The ticket says that this error existed, but when I ran `npx eslint ./components/Slider/slider.tsx`, the error was not present:
- Line 11:6
  - Error: 'className' is missing in props validation react/prop-types
