### PR TITLE
chore #487: update storybook config to discover component-level stories

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,10 +2,9 @@ import type { StorybookConfig } from '@storybook/nextjs';
 
 const config: StorybookConfig = {
   stories: [
-    '../stories/*.mdx',
     "../stories/**/*.mdx",
-    "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)",
-    "../components/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+    "../stories/**/*.stories.@(js|jsx|ts|tsx)",
+    "../components/**/*.stories.@(js|jsx|ts|tsx)"
   ],
   addons: [
     "@storybook/addon-essentials",

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,7 +4,8 @@ const config: StorybookConfig = {
   stories: [
     '../stories/*.mdx',
     "../stories/**/*.mdx",
-    "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+    "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../components/**/*.stories.@(js|jsx|mjs|ts|tsx)"
   ],
   addons: [
     "@storybook/addon-essentials",


### PR DESCRIPTION
## Description

### Before: 
Following our desired structure, stories are located alongside their components. However, Storybook was only configured to find stories in a centralized `/stories` folder.

### After: 
Modified Storybook configuration in `main.ts` by adding: 
`../components/**/*.stories.@(js|jsx|mjs|ts|tsx)`

### Summary: 
Stories can now be created and discovered within individual component folders, aligning with our current project structure. 

<!-- Example: closes #123 -->
 Closes #487 