### PR TITLE
fix #563: redirects user to dashboard following successful onboarding

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -196,7 +196,7 @@ function Onboarding() {
       form.setValue('giftCircle', data.age_group);
       form.setValue('categories', data.categories);
       form.setValue('hobbies', data.hobbies);
-      form.setValue('giftRestrictions', data.avoid);
+      form.setValue('giftRestrictions', data.avoid || '');
       form.setValue('giftPersonality', data.practical_whimsical);
       form.setValue('experienceStyle', data.cozy_adventurous);
       form.setValue('giftStyle', data.minimal_luxurious);
@@ -235,7 +235,7 @@ function Onboarding() {
             cozy_adventurous: formData.experienceStyle,
             minimal_luxurious: formData.giftStyle,
             onboarding_complete: true,
-            avatar: avatar,
+            avatar: avatar || 'https://static.vecteezy.com/system/resources/previews/024/183/525/non_2x/avatar-of-a-man-portrait-of-a-young-guy-illustration-of-male-character-in-modern-color-style-vector.jpg',
           }),
         });
 
@@ -248,7 +248,7 @@ function Onboarding() {
         if (editing) {
           router.push('/profile');
         } else {
-          window.location.href = '/dashboard';
+          router.push('/dashboard');
         }
       } catch (error) {
         console.error('Error updating profile: ', error);


### PR DESCRIPTION
## Description

### Before: 
There is no redirect after clicking the `Find My Perfect Gift` button (final step of onboarding process). 

### After: 
User is redirected to the dashboard after clicking the `Find My Perfect Gift` button. 

<!-- Example: closes #123 -->
 Closes #563 

## Testing instructions

- Clear user profile from supabase to progress through app onboarding 
 
## Additional information

1. Received the following errors when trying to replicate the bug:

<img width="531" height="208" alt="Screenshot 2025-08-21 at 3 26 39 PM" src="https://github.com/user-attachments/assets/efa1320b-0a5e-4514-a518-5bff7829287e" />

Added following lines to address validation errors, which seemed to resolve `PATCH` error as well
- line 199: `form.setValue('giftRestrictions', data.avoid || '');`
- line 238: `avatar: avatar || 'https://static.vecteezy.com/system/resources/previews/024/183/525/non_2x/avatar-of-a-man-portrait-of-a-young-guy-illustration-of-male-character-in-modern-color-style-vector.jpg',`

2. Opted to switch from full page reload (`window.location.href`) to client-side navigation (`router.push`). I think the reload may have caused the browser to behave unexpectedly, hindering the intended redirect.  

## [optional] Screenshots

https://github.com/user-attachments/assets/2427fd39-ea73-4685-879d-b5cd272e6a12

## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [x] Thread has been created in Discord and PR is linked in `gis-code-questions`