### PR TITLE
Fix: fixed warning modal issue when inviting users to a group.

### DIFF
--- a/app/gift-exchanges/[id]/page.tsx
+++ b/app/gift-exchanges/[id]/page.tsx
@@ -79,6 +79,8 @@ export default function GiftExchangePage() {
             (member: GiftExchangeMember) => member.user_id === session?.user.id,
           ),
         );
+      } else {
+        setIsUserAMember(false);
       }
     } catch (error) {
       console.error('Error fetching data:', error);


### PR DESCRIPTION
## Description

### Before: 
On the staging environment whenever you would get invited to the gift exchange (but weren't logged in) the warning modal wouldn't show up and throw errors and not load things. 

### After: 
I added the `else { setIsMember(false) } because it'll properly set the state to `false` if the person doesn't have a session. The warning model shows up if this state is `false` and before when the user didn't have a session, it was keeping it as `null`. Adding `null` into the conditional rendering wasn't working previously because it would cause it to flicker the modal before showing it because the initial state is always `null` to start.

<!-- Example: closes #123 -->
 Closes #582 

## Testing instructions

Create a gift exchange group yourself on the staging and/or localhost side and send other members the invite link to have them test if the modal pops up and they can join with no issues.


## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [x] Thread has been created in Discord and PR is linked in `gis-code-questions`