### PR TITLE
Fix: set default value to 50 and set min value to 0

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -176,9 +176,9 @@ function Onboarding() {
       categories: [],
       hobbies: '',
       giftRestrictions: '',
-      giftPersonality: 0,
-      experienceStyle: 0,
-      giftStyle: 0,
+      giftPersonality: 50,
+      experienceStyle: 50,
+      giftStyle: 50,
     },
   });
 
@@ -444,7 +444,7 @@ function Onboarding() {
                           <FormLabel>Gift Personality</FormLabel>
                           <FormControl>
                             <Slider
-                              min={-100}
+                              min={0}
                               max={100}
                               value={[field.value]}
                               onValueChange={(values) =>


### PR DESCRIPTION
## Description

### Before: 
When the slider was more to the left it wasn't submitting because initially the slider's min value was -100 and max value was 100 with 0 being the default value. Anything to the left was a negative value which failed to update supabase because in our database the value has to be `>= 0`.

### After: 
Set min value to 0 and then changed the default starting value to 50.

 Closes #567 

## [optional] Screenshots

https://github.com/user-attachments/assets/5da26cfd-697f-43ae-a6a9-b627d2f2a731


## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [x] Thread has been created in Discord and PR is linked in `gis-code-questions`