### PR TITLE
fix #560: user modal now closes when navigating to /profile

### DIFF
--- a/components/UserDropdownMenu/UserDropdownMenu.test.tsx
+++ b/components/UserDropdownMenu/UserDropdownMenu.test.tsx
@@ -40,7 +40,9 @@ describe('UserDropdownMenu', () => {
     render(<UserDropdownMenu />);
 
     await user.click(screen.getByTestId('dropdown-menu-trigger'));
-    expect(screen.getByRole('link')).toHaveTextContent('My profile');
+    expect(
+      screen.getByRole('menuitem', { name: 'My profile' }),
+    ).toHaveTextContent('My profile');
     expect(screen.getByRole('button', { name: 'Log out' })).toBeInTheDocument();
   });
 
@@ -59,14 +61,16 @@ describe('UserDropdownMenu', () => {
     render(<UserDropdownMenu />);
 
     await user.click(screen.getByTestId('dropdown-menu-trigger'));
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/profile');
+    expect(
+      screen.getByRole('menuitem', { name: 'My profile' }),
+    ).toHaveAttribute('href', '/profile');
   });
 
   it('closes the dropdown menu after clicking on an item', async () => {
     render(<UserDropdownMenu />);
 
     await user.click(screen.getByTestId('dropdown-menu-trigger'));
-    await user.click(screen.getByRole('link', { name: 'My profile' }));
+    await user.click(screen.getByRole('menuitem', { name: 'My profile' }));
     expect(screen.queryByTestId('dropdown-menu-content')).toBeNull();
   });
 });

--- a/components/UserDropdownMenu/UserDropdownMenu.tsx
+++ b/components/UserDropdownMenu/UserDropdownMenu.tsx
@@ -43,7 +43,7 @@ const UserDropdownMenu = (): JSX.Element => {
         <Avatar userAvatar={avatar} />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem data-testid="my-profile-link">
+        <DropdownMenuItem asChild data-testid="my-profile-link">
           <Link
             href="/profile"
             className="underline-offset-4 hover:underline cursor-pointer inline-flex items-center gap-2 text-sm font-medium"


### PR DESCRIPTION
## Description

### Before: 
When logged in and clicking "My profile" in the dropdown, the dropdown remained open.

### After: 
- The modal now closes when selecting the "My profile" Link.
- Fixed by adding `asChild` to the `DropdownMenuItem` containing the "My profile" Link. The `asChild` prop will need to be added on future `DropdownMenuItem`s that use the `Link` component.
- Adjusted existing unit tests to accommodate this change.

 Closes #560 

## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [ ] Thread has been created in Discord and PR is linked in `gis-code-questions`