### PR TITLE
fix: updated error message and clarified that field is required for g…

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -62,7 +62,9 @@ const stepThreeSchema = z.object({
 });
 
 const stepFourSchema = z.object({
-  giftRestrictions: z.string(),
+  giftRestrictions: z.string().min(1, {
+    message: 'If no restrictions, write "None".',
+  }),
 });
 
 const stepFiveSchema = z.object({
@@ -87,7 +89,9 @@ const FormSchema = z.object({
     message:
       'Our elves need a little more info about your interests to find the perfect gift! Please share some of your favorite activities or hobbies.',
   }),
-  giftRestrictions: z.string(),
+  giftRestrictions: z.string().min(1, {
+    message: `Our elves want to make sure your gift is just right, so please let us know if there’s anything you’d rather avoid! Whether it's preferences, restrictions, or things you simply don’t enjoy, your feedback helps us choose a gift you'll love.`,
+  }),
   giftPersonality: z.number(),
   experienceStyle: z.number(),
   giftStyle: z.number(),
@@ -417,7 +421,8 @@ function Onboarding() {
                       render={({ field }) => (
                         <FormItem>
                           <FormLabel>
-                            Is there anything your Secret Santa should avoid?
+                            Is there anything your Secret Santa should avoid? If
+                            none, write "None".
                           </FormLabel>
                           <FormControl>
                             <Textarea


### PR DESCRIPTION
## Description

### Before: 
When on the gift restrictions form during user onboarding, it is unclear that the field is required and has an unfriendly error message.

### After: 
Edited the text to make it clear that the field is required, and added a user friendly error message.


 Closes #562 

## Additional information

- Error messages only appears when user tries to submit with an empty text field.

## Screenshots

### Before
<img width="727" height="540" alt="Before" src="https://github.com/user-attachments/assets/5df77e34-7bc5-4ba4-88c4-62fab2c03330" />

### After
<img width="751" height="612" alt="After" src="https://github.com/user-attachments/assets/54241ae3-42fa-426a-b55a-f9548a9b4fd4" />

  <!-- Include before/after visuals if applicable -->

## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [ ] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [ ] Thread has been created in Discord and PR is linked in `gis-code-questions`