### PR TITLE
feat #593: multiple group toasts

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,7 +13,6 @@ export default function Dashboard() {
     GiftExchangeWithMemberCount[]
   >([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [toastData, setToastData] = useState<Array<{ variant: ToastVariants, title: string, message: string}>>([]);
   const { toast } = useToast()
 
   useEffect(() => {
@@ -41,27 +40,29 @@ export default function Dashboard() {
           const dayDifference = Math.ceil(timeDifference / (1000 * 60  * 60 * 24));
 
            if (dayDifference > 0 && dayDifference <= 3){
-           newToasts.push({
+            toast({
              variant: ToastVariants.Warning,
-             title: 'Upcoming Draw',
-             message: `The draw is in ${dayDifference} day${dayDifference < 2 ? '': 's'}!`
+             title: `Upcoming Draw - ${exchange.name}`,
+             description: `The draw is in ${dayDifference} day${dayDifference < 2 ? '': 's'}!`,
+             group: exchange.gift_exchange_id
            })
          } else if (dayDifference === 0){
-           newToasts.push({
+           toast({
             variant: ToastVariants.Success,
-            title: 'Draw Today',
-            message: `Go to your group to initiate the gift exchange draw.`
+            title: `Draw Today - ${exchange.name}`,
+            description: `Go to your group to initiate the gift exchange draw.`,
+            group: exchange.gift_exchange_id
            });
          } else if (dayDifference < 0){
-           newToasts.push({
+           toast({
             variant: ToastVariants.Error,
-            title: 'Draw date has passed', 
-            message: 'Your Secret Santas are still secret! Please draw now or reschedule drawing date.'
+            title: `Draw date has passed - ${exchange.name}`, 
+            description: 'Your Secret Santas are still secret! Please draw now or reschedule drawing date.',
+            group: exchange.gift_exchange_id
            });
          }
         }
 
-        setToastData(newToasts)
       } catch (error) {
         console.error('Failed to fetch gift exchanges:', error);
       } finally {
@@ -70,18 +71,6 @@ export default function Dashboard() {
     }
     fetchGiftExchanges();
   }, []);
-
-  useEffect(() => {
-  if (toastData.length === 0) return;
-
-  toastData.forEach((toastItem) => {
-    toast({
-      variant: toastItem.variant,
-      title: toastItem.title,
-      description: toastItem.message
-    });
-  });
-}, [toastData, toast]);
 
   return (
     <section className="min-h-screen-minus-20 flex flex-col pb-12">

--- a/app/globals.css
+++ b/app/globals.css
@@ -19,6 +19,10 @@
     --accent-foreground: 240 5.9% 10%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
+    --success: 167 50.9% 10.4%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 73.1% 56.3%;
+    --warning-foreground: 0 0% 0%;
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;
     --ring: 240 10% 3.9%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import GlobalHeader from '@/components/GlobalHeader/GlobalHeader';
 import { SnowOverlayProvider } from '@/providers/SnowOverlayProvider';
 import SnowOverlayWrapper from '@/components/SnowOverlayWrapper/SnowOverlayWrapper';
 import AuthContextProvider from '@/context/AuthContextProvider';
+import Toaster from '@/components/Toaster/Toaster';
 
 const geistSans = localFont({
   src: './fonts/GeistVF.woff',
@@ -48,6 +49,7 @@ const RootLayout = ({
             {children}
           </SnowOverlayProvider>
         </AuthContextProvider>
+        <Toaster />
       </body>
     </html>
   );

--- a/components/Toast/Toast.enum.ts
+++ b/components/Toast/Toast.enum.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+export enum ToastVariants {
+  Default = 'default',
+  Error = 'error',
+  Success = 'success',
+  Warning = 'warning',
+}

--- a/components/Toast/Toast.tsx
+++ b/components/Toast/Toast.tsx
@@ -1,0 +1,52 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+"use client"
+
+import * as React from "react"
+import * as ToastPrimitives from "@radix-ui/react-toast"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        error:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+        warning: 
+          "border-warning bg-warning text-warning-foreground",
+        success:
+          "border-success bg-success text-success-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  )
+})
+Toast.displayName = ToastPrimitives.Root.displayName
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+
+export {
+  type ToastProps,
+  Toast
+}

--- a/components/Toast/Toast.tsx
+++ b/components/Toast/Toast.tsx
@@ -7,23 +7,24 @@ import * as React from "react"
 import * as ToastPrimitives from "@radix-ui/react-toast"
 import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
+import { ToastVariants } from "./Toast.enum"
 
 const toastVariants = cva(
   "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
   {
     variants: {
       variant: {
-        default: "border bg-background text-foreground",
-        error:
+        [ToastVariants.Default]: "border bg-background text-foreground",
+        [ToastVariants.Error]:
           "destructive group border-destructive bg-destructive text-destructive-foreground",
-        warning: 
+        [ToastVariants.Warning]: 
           "border-warning bg-warning text-warning-foreground",
-        success:
+        [ToastVariants.Success]:
           "border-success bg-success text-success-foreground",
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: ToastVariants.Default,
     },
   }
 )

--- a/components/Toast/Toast.tsx
+++ b/components/Toast/Toast.tsx
@@ -6,7 +6,6 @@
 import * as React from "react"
 import * as ToastPrimitives from "@radix-ui/react-toast"
 import { cva, type VariantProps } from "class-variance-authority"
-
 import { cn } from "@/lib/utils"
 
 const toastVariants = cva(

--- a/components/ToastAction/ToastAction.tsx
+++ b/components/ToastAction/ToastAction.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+import React from 'react';
+import * as ToastPrimitives from "@radix-ui/react-toast"
+import { cn } from "@/lib/utils"
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className
+    )}
+    {...props}
+  />
+))
+ToastAction.displayName = ToastPrimitives.Action.displayName
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>
+
+export { ToastAction, type ToastActionElement }

--- a/components/ToastClose/ToastClose.test.tsx
+++ b/components/ToastClose/ToastClose.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ToastClose } from './ToastClose';
+
+describe('ToastClose', () => {
+  it('renders a button with a close icon', () => {
+    render(<ToastClose />);
+
+    const closeButton = screen.getByTestId('closeButton')
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  it("calls onClick when clicked", () => {
+    const handleClick = jest.fn();
+    render(<ToastClose onClick={handleClick} />);
+    fireEvent.click(screen.getByTestId("closeButton"));
+    expect(handleClick).toHaveBeenCalled();
+    });
+});

--- a/components/ToastClose/ToastClose.tsx
+++ b/components/ToastClose/ToastClose.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+import React from 'react';
+import { X } from "lucide-react"
+import * as ToastPrimitives from "@radix-ui/react-toast"
+import { cn } from "@/lib/utils"
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+))
+ToastClose.displayName = ToastPrimitives.Close.displayName
+
+export { ToastClose }

--- a/components/ToastClose/ToastClose.tsx
+++ b/components/ToastClose/ToastClose.tsx
@@ -17,9 +17,10 @@ const ToastClose = React.forwardRef<
       className
     )}
     toast-close=""
+    aria-label="Close"
     {...props}
   >
-    <X className="h-4 w-4" />
+    <X className="h-4 w-4" data-testid="closeButton" />
   </ToastPrimitives.Close>
 ))
 ToastClose.displayName = ToastPrimitives.Close.displayName

--- a/components/ToastDescription/ToastDescription.test.tsx
+++ b/components/ToastDescription/ToastDescription.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ToastDescription } from './ToastDescription';
+
+describe('ToastDescription', () => {
+  it('renders the description text', () => {
+    const { getByText } = render(<ToastDescription>Test Description</ToastDescription>);
+    expect(getByText('Test Description')).toBeInTheDocument();
+  });
+});

--- a/components/ToastDescription/ToastDescription.tsx
+++ b/components/ToastDescription/ToastDescription.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+import React from 'react';
+import * as ToastPrimitives from "@radix-ui/react-toast"
+import { cn } from "@/lib/utils"
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+))
+ToastDescription.displayName = ToastPrimitives.Description.displayName
+
+export { ToastDescription }

--- a/components/ToastProvider/ToastProvider.tsx
+++ b/components/ToastProvider/ToastProvider.tsx
@@ -1,0 +1,10 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+"use client"
+
+import * as ToastPrimitives from "@radix-ui/react-toast"
+
+const ToastProvider = ToastPrimitives.Provider
+
+export { ToastProvider }

--- a/components/ToastTitle/ToastTitle.test.tsx
+++ b/components/ToastTitle/ToastTitle.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ToastTitle } from './ToastTitle';
+
+describe('ToastTitle', () => {
+  it('renders the title text', () => {
+    const { getByText } = render(<ToastTitle>Test Title</ToastTitle>);
+    expect(getByText('Test Title')).toBeInTheDocument();
+  });
+});

--- a/components/ToastTitle/ToastTitle.tsx
+++ b/components/ToastTitle/ToastTitle.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+import React from "react"
+import * as ToastPrimitives from "@radix-ui/react-toast"
+import { cn } from "@/lib/utils"
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold [&+div]:text-xs", className)}
+    {...props}
+  />
+))
+ToastTitle.displayName = ToastPrimitives.Title.displayName
+
+export { ToastTitle }

--- a/components/ToastViewport/ToastViewport.tsx
+++ b/components/ToastViewport/ToastViewport.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+import React from 'react';
+import * as ToastPrimitives from "@radix-ui/react-toast"
+import { cn } from "@/lib/utils"
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className
+    )}
+    {...props}
+  />
+))
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+
+export { ToastViewport }

--- a/components/Toaster/Toaster.test.tsx
+++ b/components/Toaster/Toaster.test.tsx
@@ -1,10 +1,7 @@
 import Toaster from './Toaster';
-import { ToastVariants } from '../Toast/Toast.enum';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { useToast } from '@/hooks/use-toast';
-import { Toast } from '@radix-ui/react-toast';
 
 jest.mock("@/hooks/use-toast", () => ({
   useToast: jest.fn(),
@@ -62,5 +59,29 @@ describe('ToastNotification', () => {
       expect(dismissButton).toBeInTheDocument();
     }
   );
+it.each(Object.entries(variantTestCases))(
+    "should dismiss the %s toast when the dismiss button is clicked",
+    async (key, value) => {
 
+      const mockDismiss = jest.fn();
+      (useToast as jest.Mock).mockReturnValue({
+        toasts: [{
+          id: "test-id",
+          title: value.title,
+          description: value.description,
+          variant: key,
+          onOpenChange: mockDismiss,
+        }],
+        toast: jest.fn(),
+        dismiss: mockDismiss,
+      });
+
+      render(<Toaster />);
+
+      const dismissButton = screen.getByRole('button', { name: 'Close' });
+      fireEvent.click(dismissButton);
+
+      expect(mockDismiss).toHaveBeenCalled();
+    }
+  );
 })

--- a/components/Toaster/Toaster.test.tsx
+++ b/components/Toaster/Toaster.test.tsx
@@ -1,0 +1,66 @@
+import Toaster from './Toaster';
+import { ToastVariants } from '../Toast/Toast.enum';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useToast } from '@/hooks/use-toast';
+import { Toast } from '@radix-ui/react-toast';
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: jest.fn(),
+  toast: jest.fn(),
+}));
+
+const variantTestCases = {
+  default: {
+    title: 'Info!',
+    description: 'Info message',
+  },
+  error: {
+    title: 'Error!',
+    description: 'This is an error message',
+  },
+  warning: {
+    title: 'Warning',
+    description: 'This is a warning message',
+  },
+  success: {
+    title: 'Success!',
+    description: 'This is a success message',
+  },
+};
+
+const setupToastTest = (key: string, value: any) => {
+  (useToast as jest.Mock).mockReturnValue({
+    toasts: [{
+      id: "test-id",
+      title: value.title,
+      description: value.description,
+      variant: key,
+    }],
+    toast: jest.fn(),
+    dismiss: jest.fn(),
+  });
+  render(<Toaster />);
+};
+
+describe('ToastNotification', () => {
+  it.each(Object.entries(variantTestCases))(
+  "should render the %s toast correctly",
+  (key, value) => {
+    setupToastTest(key, value);
+    expect(screen.getByText(value.title)).toBeInTheDocument();
+    expect(screen.getByText(value.description)).toBeInTheDocument();
+  }
+);
+
+  it.each(Object.entries(variantTestCases))(
+    "should render the dismiss button for the %s variant", async (key, value) => {
+      setupToastTest(key, value);
+
+      const dismissButton = screen.queryByRole('button', { name: 'Close' });
+      expect(dismissButton).toBeInTheDocument();
+    }
+  );
+
+})

--- a/components/Toaster/Toaster.tsx
+++ b/components/Toaster/Toaster.tsx
@@ -23,7 +23,7 @@ const Toaster = (): JSX.Element => {
     <ToastProvider>
       {toasts.map(function ({ id, title, description, action, ...props }) {
         return (
-          <Toast key={id} {...props}>
+          <Toast key={id} {...props} data-testid="toast">
             <div className="grid gap-1">
               {title && <ToastTitle>{title}</ToastTitle>}
               {description && (
@@ -31,7 +31,7 @@ const Toaster = (): JSX.Element => {
               )}
             </div>
             {action}
-            <ToastClose />
+            <ToastClose data-testid="toastClose" />
           </Toast>
         )
       })}

--- a/components/Toaster/Toaster.tsx
+++ b/components/Toaster/Toaster.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+"use client"
+
+import { useToast } from "@/hooks/use-toast"
+import { Toast } from "@/components/Toast/Toast"
+import { ToastTitle } from "../ToastTitle/ToastTitle"
+import { ToastDescription } from "../ToastDescription/ToastDescription"
+import { ToastClose } from "../ToastClose/ToastClose"
+import { ToastViewport } from "../ToastViewport/ToastViewport"
+import { ToastProvider } from "../ToastProvider/ToastProvider"
+import { JSX } from "react"
+
+/**
+ * Renders and manages display of toast notifications.
+ * @returns {JSX.Element} The rendered toast notification. 
+ */
+const Toaster = (): JSX.Element => {
+  const { toasts } = useToast()
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && (
+                <ToastDescription>{description}</ToastDescription>
+              )}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        )
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  )
+}
+
+export default Toaster

--- a/components/Toaster/Toaster.tsx
+++ b/components/Toaster/Toaster.tsx
@@ -35,7 +35,7 @@ const Toaster = (): JSX.Element => {
           </Toast>
         )
       })}
-      <ToastViewport />
+      <ToastViewport className="flex flex-col gap-2"/>
     </ToastProvider>
   )
 }

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -6,10 +6,8 @@
 // Inspired by react-hot-toast library
 import * as React from "react"
 
-import type {
-  ToastActionElement,
-  ToastProps,
-} from "@/components/Toast/Toast"
+import type { ToastActionElement } from "@/components/ToastAction/ToastAction"
+import type { ToastProps } from "@/components/Toast/Toast"
 
 const TOAST_LIMIT = 1
 const TOAST_REMOVE_DELAY = 1000000

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import * as React from "react"
 import type { ToastActionElement } from "@/components/ToastAction/ToastAction"
 import type { ToastProps } from "@/components/Toast/Toast"
 
-const TOAST_LIMIT = 1
+const TOAST_LIMIT = 5
 const TOAST_REMOVE_DELAY = 1000000
 
 type ToasterToast = ToastProps & {
@@ -17,6 +17,7 @@ type ToasterToast = ToastProps & {
   title?: React.ReactNode
   description?: React.ReactNode
   action?: ToastActionElement
+  group?: string;
 }
 
 const actionTypes = {
@@ -78,6 +79,13 @@ const addToRemoveQueue = (toastId: string) => {
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case "ADD_TOAST":
+      const isDuplicate = state.toasts.some(
+        (toast) => toast.title === action.toast.title && toast.description === action.toast.description);
+
+      if(isDuplicate){
+        return state;
+      }
+
       return {
         ...state,
         toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -1,0 +1,197 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+"use client"
+
+// Inspired by react-hot-toast library
+import * as React from "react"
+
+import type {
+  ToastActionElement,
+  ToastProps,
+} from "@/components/Toast/Toast"
+
+const TOAST_LIMIT = 1
+const TOAST_REMOVE_DELAY = 1000000
+
+type ToasterToast = ToastProps & {
+  id: string
+  title?: React.ReactNode
+  description?: React.ReactNode
+  action?: ToastActionElement
+}
+
+const actionTypes = {
+  ADD_TOAST: "ADD_TOAST",
+  UPDATE_TOAST: "UPDATE_TOAST",
+  DISMISS_TOAST: "DISMISS_TOAST",
+  REMOVE_TOAST: "REMOVE_TOAST",
+} as const
+
+let count = 0
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
+  return count.toString()
+}
+
+type ActionType = typeof actionTypes
+
+type Action =
+  | {
+      type: ActionType["ADD_TOAST"]
+      toast: ToasterToast
+    }
+  | {
+      type: ActionType["UPDATE_TOAST"]
+      toast: Partial<ToasterToast>
+    }
+  | {
+      type: ActionType["DISMISS_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+  | {
+      type: ActionType["REMOVE_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({
+      type: "REMOVE_TOAST",
+      toastId: toastId,
+    })
+  }, TOAST_REMOVE_DELAY)
+
+  toastTimeouts.set(toastId, timeout)
+}
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      }
+
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
+        ),
+      }
+
+    case "DISMISS_TOAST": {
+      const { toastId } = action
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId)
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id)
+        })
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+              ...t,
+              open: false,
+            }
+            : t
+        ),
+      }
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        }
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      }
+  }
+}
+
+const listeners: Array<(state: State) => void> = []
+
+let memoryState: State = { toasts: [] }
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action)
+  listeners.forEach((listener) => {
+    listener(memoryState)
+  })
+}
+
+type Toast = Omit<ToasterToast, "id">
+
+function toast({ ...props }: Toast) {
+  const id = genId()
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: "UPDATE_TOAST",
+      toast: { ...props, id },
+    })
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss()
+      },
+    },
+  })
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  }
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState)
+
+  React.useEffect(() => {
+    listeners.push(setState)
+    return () => {
+      const index = listeners.indexOf(setState)
+      if (index > -1) {
+        listeners.splice(index, 1)
+      }
+    }
+  }, [state])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  }
+}
+
+export { useToast, toast }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slider": "^1.2.1",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-toast": "^1.2.15",
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.46.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.2.0(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.15
+        version: 1.2.15(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@supabase/auth-helpers-nextjs':
         specifier: ^0.10.0
         version: 0.10.0(@supabase/supabase-js@2.49.4)
@@ -1408,6 +1411,9 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
   '@radix-ui/react-alert-dialog@1.1.7':
     resolution: {integrity: sha512-7Gx1gcoltd0VxKoR8mc+TAVbzvChJyZryZsTam0UhoL92z0L+W8ovxvcgvd+nkz24y7Qc51JQKBAGe4+825tYw==}
     peerDependencies:
@@ -1528,6 +1534,19 @@ packages:
 
   '@radix-ui/react-dismissable-layer@1.1.10':
     resolution: {integrity: sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1726,6 +1745,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.0.3':
     resolution: {integrity: sha512-Pf/t/GkndH7CQ8wE2hbkXA+WyZ83fhQQn5DDmwDiDo6AwN/fhaH8oqZ0jRjMrO2iaMhDi6P1HRx6AZwyMinY1g==}
     peerDependencies:
@@ -1848,6 +1880,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
@@ -1931,6 +1976,19 @@ packages:
 
   '@radix-ui/react-visually-hidden@1.1.3':
     resolution: {integrity: sha512-oXSF3ZQRd5fvomd9hmUCb2EHSZbPp3ZSHAHJJU/DlF9XoFkJBBW8RHU/E8WEH+RbSfJd/QFA0sl8ClJXknBwHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7464,6 +7522,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
   '@radix-ui/react-alert-dialog@1.1.7(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -7575,6 +7635,19 @@ snapshots:
   '@radix-ui/react-dismissable-layer@1.1.10(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.20)(react@18.3.1)
@@ -7782,6 +7855,16 @@ snapshots:
       '@types/react': 18.3.20
       '@types/react-dom': 18.3.6(@types/react@18.3.20)
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
   '@radix-ui/react-primitive@2.0.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.0(@types/react@18.3.20)(react@18.3.1)
@@ -7924,6 +8007,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.20
 
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.20)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.20)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -7988,6 +8091,15 @@ snapshots:
   '@radix-ui/react-visually-hidden@1.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
+      '@types/react-dom': 18.3.6(@types/react@18.3.20)
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.6(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
 import type { Config } from 'tailwindcss';
 import tailwindcssMotion from 'tailwindcss-motion';
 
@@ -58,6 +61,14 @@ export default {
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',
+        },
+        success: {
+          DEFAULT: 'hsl(var(--success))',
+          foreground: 'hsl(var(--success-foreground))',
+        },
+        warning: {
+          DEFAULT: 'hsl(var(--warning))',
+          foreground: 'hsl(var(--warning-foreground))',
         },
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',


### PR DESCRIPTION
## Description

### Before: 
Only one toast was visible at a time, regardless of the number of Secret Santa groups meeting notification criteria

### After: 

- Toast notifications for each group enabled for following variants: 
  - `success` : gift drawing date same as current date
  - `warning` : 1-3 days between draw date and current date 
  - `error`: drawing date has elapsed relative to current date 

<!-- Example: closes #123 -->
 Closes #593 

## Testing instructions

Create multiple groups with different conditions
 
## Additional information

- Modified `ToastViewport` to add gap between toasts
- Added group names to distinguish between different toasts 

## [optional] Screenshots
<img width="410" height="204" alt="Screenshot 2025-09-15 at 8 11 24 PM" src="https://github.com/user-attachments/assets/29dd4217-d31e-4619-bb19-1017ad95765c" />

## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [x] Thread has been created in Discord and PR is linked in `gis-code-questions`