### PR TITLE
fix #288: addressed linting issues with drawGiftExchange

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -50,7 +50,6 @@ components/Popover/popover.tsx
 components/ProfileCard/ProfileCard.tsx
 components/Select/select.tsx
 components/SnowOverlayWrapper/react-snow-overlay.d.ts
-lib/drawGiftExchange.ts
 lib/generateAndStoreSuggestions.ts
 lib/getAmazonImage.ts
 lib/supabase/middleware.ts

--- a/lib/drawGiftExchange.ts
+++ b/lib/drawGiftExchange.ts
@@ -1,13 +1,22 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
 import { SupabaseClient } from '@supabase/supabase-js';
 import { generateAndStoreSuggestions } from './generateAndStoreSuggestions';
 
-// util function to draw gift exchange names
-// this function can be called from an API route
-// or from a scheduled job
+/**
+ * Performs random drawing for matching of users in gift exchange.
+ * If successful, updates the record from gift_exchanges and the
+ * related gift_exchange_members to reflect the results of the drawing.
+ * @param {SupabaseClient} supabase - Supabase client instance
+ * @param {string} exchangeId - Unique ID for the gift exchange
+ * @returns {Promise<{success: boolean}>} - Promise resolving to an object with a success indicator
+ * @throws {Error} - Will throw if drawing criteria is not correct or if any DB call fails
+ */
 export async function drawGiftExchange(
   supabase: SupabaseClient,
   exchangeId: string,
-) {
+): Promise<{ success: boolean }> {
   // Get exchange and verify ownership
   const { data: exchange, error: exchangeError } = await supabase
     .from('gift_exchanges')


### PR DESCRIPTION
## Description
### Before: 
There were three linting errors: header missing, return type missing, and JSDoc comment missing

### After: 
Addressed the ESlint errors by adding a header, JSDoc comments and an explicit return type.
Removed `lib/drawGiftExchange.ts` from `.eslintignore`

<!-- Example: closes #123 -->
 Closes #288  
 
## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [x] Thread has been created in Discord and PR is linked in `gis-code-questions`