### PR TITLE
test #195: created unit test for InviteCard component

### DIFF
--- a/components/InviteCard/InviteCard.test.tsx
+++ b/components/InviteCard/InviteCard.test.tsx
@@ -1,0 +1,104 @@
+// Copyright (c) Gridiron Survivor.
+// Licensed under the MIT License.
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { InviteCard } from './InviteCard';
+
+describe('InviteCard Component', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+
+    user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    delete (window as any).location;
+    window.location = { href: 'http://localhost:4000/test-url' } as any;
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  const renderComponent = () => {
+    render(<InviteCard />);
+    return {
+      getButton: () => screen.getByRole('button'),
+    };
+  };
+
+  it('renders the component with correct elements', () => {
+    const { getButton } = renderComponent();
+
+    expect(getButton()).toBeInTheDocument();
+    expect(screen.getByTestId('card')).toBeInTheDocument();
+    expect(screen.getByText('Invite Others')).toBeInTheDocument();
+  });
+
+  it('displays the text "Copy invite link" upon initial render', () => {
+    const { getButton } = renderComponent();
+    expect(getButton()).toHaveTextContent(/copy/i);
+  });
+
+  it('displays the text "Copied!" after pressing the button', async () => {
+    const { getButton } = renderComponent();
+
+    await user.click(getButton());
+
+    await waitFor(() => {
+      expect(getButton()).toHaveTextContent(/copied/i);
+    });
+  });
+
+  it('reverts to button original state after 2000ms', async () => {
+    const { getButton } = renderComponent();
+
+    await user.click(getButton());
+    await waitFor(() => {
+      expect(getButton()).toHaveTextContent(/copied/i);
+    });
+    jest.advanceTimersByTime(2000);
+
+    await waitFor(() => {
+      expect(getButton()).toHaveTextContent(/copy/i);
+      expect(screen.queryByText(/copied/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('copies current URL to clipboard after pressing the button', async () => {
+    const mockWriteText = jest.fn().mockResolvedValue(undefined);
+    navigator.clipboard.writeText = mockWriteText;
+    const { getButton } = renderComponent();
+
+    await user.click(getButton());
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith(
+        'http://localhost:4000/test-url',
+      );
+    });
+  });
+
+  it('logs clipboard API errors to the console correctly', async () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    navigator.clipboard.writeText = jest
+      .fn()
+      .mockRejectedValue(new Error('Clipboard error!'));
+    const { getButton } = renderComponent();
+
+    await user.click(getButton());
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to copy:',
+        expect.any(Error),
+      );
+    });
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Description

### Before: 
The `InviteCard` component lacked unit tests.

### After: 
#### Unit tests have been added for `InviteCard` component:
- renders card elements: card, text, button
- button displays correct text upon initial render
- button displays new text immediately after button click
- button text reverts to original text after 2000ms
- when button is clicked, the mocked value in `window.location.href` is copied to the mocked `navigator.clipboard.writeText` function
- a simulated error (rejected promise) in the call to `navigator.clipboard.writeText` results in an error being logged to the console

<!-- Example: closes #123 -->
 Closes #195  

## Screenshot
<img width="268" height="143" alt="Invite_card_screenshot" src="https://github.com/user-attachments/assets/eb191757-ba84-4987-b86a-d86f0c11ed54" />

## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [x] Thread has been created in Discord and PR is linked in `gis-code-questions`