### PR TITLE
fix #564: Sliders now start at correct default during onboarding

### DIFF
--- a/app/onboarding/onboarding-form/onboarding-form.tsx
+++ b/app/onboarding/onboarding-form/onboarding-form.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Gridiron Survivor.
 // Licensed under the MIT License.
 
-import { useState, useEffect, JSX } from 'react';
+import { useState, useEffect, type JSX } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { z } from 'zod';
 import { useForm, Controller } from 'react-hook-form';
@@ -198,14 +198,30 @@ export const Onboarding = ({
       });
       const data = await response.json();
       setName(data.display_name);
-      form.setValue('name', data.display_name);
-      form.setValue('giftCircle', data.age_group);
-      form.setValue('categories', data.categories);
-      form.setValue('hobbies', data.hobbies);
-      form.setValue('giftRestrictions', data.avoid);
-      form.setValue('giftPersonality', data.practical_whimsical);
-      form.setValue('experienceStyle', data.cozy_adventurous);
-      form.setValue('giftStyle', data.minimal_luxurious);
+      if (data.display_name) {
+        form.setValue('name', data.display_name);
+      }
+      if (data.age_group) {
+        form.setValue('giftCircle', data.age_group);
+      }
+      if (data.categories) {
+        form.setValue('categories', data.categories);
+      }
+      if (data.hobbies) {
+        form.setValue('hobbies', data.hobbies);
+      }
+      if (data.avoid) {
+        form.setValue('giftRestrictions', data.avoid);
+      }
+      if (data.practical_whimsical) {
+        form.setValue('giftPersonality', data.practical_whimsical);
+      }
+      if (data.cozy_adventurous) {
+        form.setValue('experienceStyle', data.cozy_adventurous);
+      }
+      if (data.minimal_luxurious) {
+        form.setValue('giftStyle', data.minimal_luxurious);
+      }
     };
     fetchProfile();
   }, [form]);
@@ -318,6 +334,7 @@ export const Onboarding = ({
                       name="name"
                       render={({ field }) => (
                         <FormItem>
+                          {/* Possible grammatical improvement: What name will you go by? or What should we call you?*/}
                           <FormLabel>How should we call you?</FormLabel>
                           <FormControl>
                             <Input {...field} />


### PR DESCRIPTION
## Description

### Before: 
During the onboarding process, the "Gift Compass" sliders display at value 0 (all the way to the left) even though the default value for all 3 is set to "50". When the user attempts to progress to the next screen without adjusting the slider(s), an error is displayed "Expected number, received null"

### After: 
Sliders display default for new users correctly and the error no longer is displayed.

### Additional information:
The error was caused because user data fetched in `useEffect` was overwriting the default values being passed to the form, even when those values are `null`. I added `if` checks for each of the values, allowing the default form value to be overwritten only if there is a truthy value in the fetched data. Another, more concise, syntax would be e.g.: `form.setValue('giftStyle', data.minimal_luxurious || DEFAULT_FORM_VALUES.giftStyle)` but I think the explicit `if` check is a bit more clear.

Long term, perhaps validating the fetched user data with Zod or another technique would be a more robust solution.

### Also:
I made a comment of a possible grammatical improvement. If approved, this could potentially be included in this PR.

<!-- Example: closes #123 -->
 Closes #564  

## Screenshot
<img width="345" height="464" alt="gift_compass_screenshot" src="https://github.com/user-attachments/assets/2266f834-cb6a-499e-b9de-649577f5ef35" />


## Pre-submission checklist

- [x] Code builds and passes locally
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format (e.g. `test #001: created unit test for __ component`)
- [x] Request reviews from the `Peer Code Reviewers` and `Senior+ Code Reviewers` groups
- [x] Thread has been created in Discord and PR is linked in `gis-code-questions`